### PR TITLE
# Version 0.5.0 .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# Version 0.5.0 
+
+v0.5.0 New features:
+
+
+    1. Remove all unwrap() calls.
+    
+    2. Redefined the errors exposed to the outside (encapsulated by thiserror) as libs to never expose `anyhow::Error` to the outside.
+    
+      2.1. Set separate `TaskError`. for `Task`-related operations.
+      2.2. Set separate `HandleInstanceError`. for `Task-Instance`-related operations.
+    
+    
+    3. Optimized shell command parsing function, set exclusive pipeline for derived subprocesses -stderr.
+
+
+Update dependency :
+    Add, `thiserror`.
+
+
+Enriched documentation.
+
+
 # Version 0.4.0 
 
 v0.4.0 New features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delay_timer"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["binchengZhao <binchengZhao@outlook.com>"]
 edition = "2018"
 repository = "https://github.com/BinChengZhao/delay-timer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ concat-idents = "1.1.2"
 async-trait = "^0.1.48"
 event-listener = "^2.5.1"
 log = "^0.4.14"
+thiserror = "^1.0.24"
 
 
 # Optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delay_timer"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["binchengZhao <binchengZhao@outlook.com>"]
 edition = "2018"
 repository = "https://github.com/BinChengZhao/delay-timer"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
 
     // Develop a print job that runs in an asynchronous cycle.
     // A chain of task instances.
-    let task_instance_chain = delay_timer.insert_task(build_task_async_print())?;
+    let task_instance_chain = delay_timer.insert_task(build_task_async_print()?)?;
 
     // Get the running instance of task 1.
     let task_instance = task_instance_chain.next_with_wait()?;
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn build_task_async_print() -> Task {
+fn build_task_async_print() -> Result<Task, TaskError> {
     let mut task_builder = TaskBuilder::default();
 
     let body = create_async_fn_body!({
@@ -72,7 +72,6 @@ fn build_task_async_print() -> Task {
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
         .set_maximun_parallel_runable_num(2)
         .spawn(body)
-        .unwrap()
 }
 
  ```
@@ -96,7 +95,7 @@ async fn main() -> Result<()> {
     let delay_timer = DelayTimerBuilder::default().build();
 
     // Develop a print job that runs in an asynchronous cycle.
-    let task_instance_chain = delay_timer.insert_task(build_task_async_print())?;
+    let task_instance_chain = delay_timer.insert_task(build_task_async_print()?)?;
 
     // Get the running instance of task 1.
     let task_instance = task_instance_chain.next_with_async_wait().await?;
@@ -112,7 +111,7 @@ async fn main() -> Result<()> {
     delay_timer.stop_delay_timer()
 }
 
-fn build_task_async_print() -> Task {
+fn build_task_async_print() -> Result<Task, TaskError> {
     let mut task_builder = TaskBuilder::default();
 
     let body = create_async_fn_body!({
@@ -128,7 +127,6 @@ fn build_task_async_print() -> Task {
         .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
         .set_maximun_parallel_runable_num(2)
         .spawn(body)
-        .unwrap()
 }
 
 
@@ -161,8 +159,7 @@ fn build_task_async_print() -> Task {
      .set_frequency_by_candy(CandyFrequency::CountDown(9, CandyCron::Secondly))
      .set_task_id(1)
      .set_maximun_parallel_runable_num(3)
-     .spawn(body)
-     .unwrap();
+     .spawn(body)?;
 
  delay_timer.add_task(task);
 
@@ -176,7 +173,7 @@ fn build_task_async_print() -> Task {
  use delay_timer::prelude::*;
  use hyper::{Client, Uri};
 
-fn build_task_customized_async_task() -> Task {
+fn build_task_customized_async_task() -> Result<Task, TaskError> {
     let mut task_builder = TaskBuilder::default();
 
     let body = generate_closure_template("delay_timer is easy to use. .".into());
@@ -185,7 +182,6 @@ fn build_task_customized_async_task() -> Task {
         .set_task_id(5)
         .set_maximum_running_time(5)
         .spawn(body)
-        .unwrap()
 }
 
 pub fn generate_closure_template(

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Licensed under either of
 
 ## To Do List
 - [x] Support tokio Ecology.
-- [ ] Disable unwrap related methods that will panic.
+- [x] Disable unwrap related methods that will panic.
 - [ ] Thread and running task quit when delayTimer drop.
 - [ ] neaten todo in code, replenish tests and benchmark.
 - [ ] batch-opration.

--- a/build/build.rs
+++ b/build/build.rs
@@ -1,11 +1,11 @@
 extern crate autocfg;
 
 use autocfg::emit;
-use rustc_version::{version, version_meta, Channel, Version};
+use rustc_version::{version, version_meta, Channel, Result, Version};
 
-fn main() {
+fn main() -> Result<()> {
     // Set cfg flags depending on release channel
-    match version_meta().unwrap().channel {
+    match version_meta()?.channel {
         Channel::Stable => {
             println!("cargo:rustc-cfg=RUSTC_IS_STABLE");
         }
@@ -22,11 +22,12 @@ fn main() {
     }
 
     // Check for a minimum version
-    if version().unwrap() >= Version::parse("1.51.0").unwrap() {
+    if version()? >= Version::parse("1.51.0")? {
         println!("cargo:rustc-cfg=SPLIT_INCLUSIVE_COMPATIBLE");
     }
 
     // (optional) We don't need to rerun for anything external.
     // In order to see the compilation parameters at `cargo check --verbose` time, keep it.
     autocfg::rerun_path("build.rs");
+    Ok(())
 }

--- a/examples/cycle_tokio_task.rs
+++ b/examples/cycle_tokio_task.rs
@@ -59,7 +59,7 @@ pub fn generate_closure_template(
         let future_inner = async_template(get_timestamp() as i32, name.clone());
 
         let future = async move {
-            future_inner.await;
+            future_inner.await.ok();
             context.finishe_task(None).await;
         };
 

--- a/examples/cycle_tokio_task.rs
+++ b/examples/cycle_tokio_task.rs
@@ -11,10 +11,10 @@ fn main() -> Result<()> {
     let delay_timer = DelayTimerBuilder::default().tokio_runtime(None).build();
 
     // Develop a task that runs in an asynchronous cycle (using a custom asynchronous template).
-    delay_timer.add_task(build_task_customized_async_task())?;
+    delay_timer.add_task(build_task_customized_async_task()?)?;
 
     // Develop a task that runs in an asynchronous cycle to wake up the current thread.
-    delay_timer.add_task(build_wake_task())?;
+    delay_timer.add_task(build_wake_task()?)?;
     park();
 
     // No new tasks are accepted; running tasks are not affected.
@@ -23,20 +23,19 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn build_task_customized_async_task() -> Task {
+fn build_task_customized_async_task() -> Result<Task> {
     let mut task_builder = TaskBuilder::default();
 
     let body = generate_closure_template("'delay_timer-is-easy-to-use.'".into());
 
-    task_builder
+    Ok(task_builder
         .set_frequency_by_candy(CandyFrequency::Repeated(AuspiciousDay::Work))
         .set_task_id(5)
         .set_maximum_running_time(15)
-        .spawn(body)
-        .unwrap()
+        .spawn(body)?)
 }
 
-fn build_wake_task() -> Task {
+fn build_wake_task() -> Result<Task> {
     let mut task_builder = TaskBuilder::default();
 
     let thread: Thread = current();
@@ -46,12 +45,11 @@ fn build_wake_task() -> Task {
         create_default_delay_task_handler()
     };
 
-    task_builder
+    Ok(task_builder
         .set_frequency_by_candy(CandyFrequency::Repeated(AuspiciousDay::Wake))
         .set_task_id(7)
         .set_maximum_running_time(50)
-        .spawn(body)
-        .unwrap()
+        .spawn(body)?)
 }
 
 pub fn generate_closure_template(
@@ -69,20 +67,21 @@ pub fn generate_closure_template(
     }
 }
 
-pub async fn async_template(id: i32, name: String) {
+pub async fn async_template(id: i32, name: String) -> Result<()> {
     let client = Client::new();
 
     //The default connector does not handle TLS.
     //Speaking to https destinations will require configuring a connector that implements TLS.
     //So use http for test.
     let url = format!("http://httpbin.org/get?id={}&name={}", id, name);
-    let uri: Uri = url.parse().unwrap();
+    let uri: Uri = url.parse()?;
 
-    let res = client.get(uri).await.unwrap();
+    let res = client.get(uri).await?;
     println!("Response: {}", res.status());
     // Concatenate the body stream into a single buffer...
-    let buf = hyper::body::to_bytes(res).await.unwrap();
+    let buf = hyper::body::to_bytes(res).await?;
     println!("body: {:?}", buf);
+    Ok(())
 }
 
 enum AuspiciousDay {

--- a/examples/demo_async_std.rs
+++ b/examples/demo_async_std.rs
@@ -3,7 +3,7 @@ use delay_timer::prelude::*;
 use anyhow::Result;
 
 use smol::Timer;
-use std::time::Duration;
+use std::{ops::Deref, time::Duration};
 
 // You can replace the 62 line with the command you expect to execute.
 #[async_std::main]
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     delay_timer.remove_task(1)?;
 
     // No new tasks are accepted; running tasks are not affected.
-    delay_timer.stop_delay_timer()
+    Ok(delay_timer.stop_delay_timer()?)
 }
 
 fn build_task_async_print() -> Task {
@@ -47,10 +47,11 @@ fn build_task_async_print() -> Task {
 
         println!("create_async_fn_body:i'success");
     });
-
+    let s = String::from("*/6 * * * * * *");
+    let s_r = (&s).deref();
     task_builder
         .set_task_id(1)
-        .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
+        .set_frequency(Frequency::Repeated(s_r))
         .set_maximun_parallel_runable_num(2)
         .spawn(body)
         .unwrap()

--- a/examples/demo_async_std.rs
+++ b/examples/demo_async_std.rs
@@ -12,10 +12,10 @@ async fn main() -> Result<()> {
     let delay_timer = DelayTimerBuilder::default().build();
 
     // Develop a print job that runs in an asynchronous cycle.
-    let task_instance_chain = delay_timer.insert_task(build_task_async_print())?;
+    let task_instance_chain = delay_timer.insert_task(build_task_async_print()?)?;
 
     // Develop a php script shell-task that runs in an asynchronous cycle.
-    let shell_task_instance_chain = delay_timer.insert_task(build_task_async_execute_process())?;
+    let shell_task_instance_chain = delay_timer.insert_task(build_task_async_execute_process()?)?;
 
     // Get the running instance of task 1.
     let task_instance = task_instance_chain.next_with_async_wait().await?;
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     Ok(delay_timer.stop_delay_timer()?)
 }
 
-fn build_task_async_print() -> Task {
+fn build_task_async_print() -> Result<Task, TaskError> {
     let mut task_builder = TaskBuilder::default();
 
     let body = create_async_fn_body!({
@@ -54,10 +54,9 @@ fn build_task_async_print() -> Task {
         .set_frequency(Frequency::Repeated(s_r))
         .set_maximun_parallel_runable_num(2)
         .spawn(body)
-        .unwrap()
 }
 
-fn build_task_async_execute_process() -> Task {
+fn build_task_async_execute_process() -> Result<Task, TaskError> {
     let mut task_builder = TaskBuilder::default();
 
     let body = unblock_process_task_fn("php /home/open/project/rust/repo/myself/delay_timer/examples/try_spawn.php >> ./try_spawn.txt".into());
@@ -67,5 +66,4 @@ fn build_task_async_execute_process() -> Task {
         .set_maximum_running_time(10)
         .set_maximun_parallel_runable_num(1)
         .spawn(body)
-        .unwrap()
 }

--- a/examples/demo_async_tokio.rs
+++ b/examples/demo_async_tokio.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     delay_timer.remove_task(1)?;
 
     // No new tasks are accepted; running tasks are not affected.
-    delay_timer.stop_delay_timer()
+    Ok(delay_timer.stop_delay_timer()?)
 }
 
 fn build_task_async_print() -> Task {

--- a/examples/demo_async_tokio.rs
+++ b/examples/demo_async_tokio.rs
@@ -15,10 +15,10 @@ async fn main() -> Result<()> {
     let delay_timer = DelayTimerBuilder::default().build();
 
     // Develop a print job that runs in an asynchronous cycle.
-    let task_instance_chain = delay_timer.insert_task(build_task_async_print())?;
+    let task_instance_chain = delay_timer.insert_task(build_task_async_print()?)?;
 
     // Develop a php script shell-task that runs in an asynchronous cycle.
-    let shell_task_instance_chain = delay_timer.insert_task(build_task_async_execute_process())?;
+    let shell_task_instance_chain = delay_timer.insert_task(build_task_async_execute_process()?)?;
 
     // Get the running instance of task 1.
     let task_instance = task_instance_chain.next_with_async_wait().await?;
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     Ok(delay_timer.stop_delay_timer()?)
 }
 
-fn build_task_async_print() -> Task {
+fn build_task_async_print() -> Result<Task, TaskError> {
     let mut task_builder = TaskBuilder::default();
 
     let body = create_async_fn_body!({
@@ -57,10 +57,9 @@ fn build_task_async_print() -> Task {
         .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
         .set_maximun_parallel_runable_num(2)
         .spawn(body)
-        .unwrap()
 }
 
-fn build_task_async_execute_process() -> Task {
+fn build_task_async_execute_process() -> Result<Task, TaskError> {
     let mut task_builder = TaskBuilder::default();
 
     let body = unblock_process_task_fn("php /home/open/project/rust/repo/myself/delay_timer/examples/try_spawn.php >> ./try_spawn.txt".into());
@@ -70,5 +69,4 @@ fn build_task_async_execute_process() -> Task {
         .set_maximum_running_time(10)
         .set_maximun_parallel_runable_num(1)
         .spawn(body)
-        .unwrap()
 }

--- a/examples/increase.rs
+++ b/examples/increase.rs
@@ -101,8 +101,9 @@ fn get_wake_fn(
 
 fn get_async_fn() -> impl Copy + Fn(TaskContext) -> Box<dyn DelayTaskHandler> {
     create_async_fn_body!({
-        let mut res = surf::get("https://httpbin.org/get").await.unwrap();
-        let body_str = res.body_string().await.unwrap();
-        println!("{}", body_str);
+        if let Ok(mut res) = surf::get("https://httpbin.org/get").await {
+            let body_str = res.body_string().await.unwrap_or_default();
+            println!("{}", body_str);
+        }
     })
 }

--- a/examples/increase.rs
+++ b/examples/increase.rs
@@ -28,8 +28,10 @@ fn main() -> AnyResult<()> {
     // The Sync-Task run_flay.
     let mut run_flag = Arc::new(AtomicUsize::new(0));
     // cross thread share raw-pointer.
-    let run_flag_ref: SafePointer =
-        SafePointer(NonNull::new(&mut run_flag as *mut Arc<AtomicUsize>)?);
+    let run_flag_ref: SafePointer = SafePointer(
+        NonNull::new(&mut run_flag as *mut Arc<AtomicUsize>)
+            .ok_or_else(|| anyhow!("Can't init NonNull."))?,
+    );
 
     // Sync-Task body.
     let body = get_increase_fn(run_flag_ref);
@@ -63,6 +65,7 @@ fn main() -> AnyResult<()> {
     delay_timer.add_task(task)?;
 
     park();
+    Ok(())
 }
 
 fn get_increase_fn(

--- a/examples/profile_memory.rs
+++ b/examples/profile_memory.rs
@@ -12,7 +12,7 @@ struct RequstBody {
 impl RequstBody {
     fn fake_request_body() -> Self {
         let string_buf = [16u16, 16u16, 16u16].repeat(10000);
-        let cron_expression = String::from_utf16(&string_buf).unwrap();
+        let cron_expression = String::from_utf16(&string_buf).unwrap_or_default();
         Self {
             cron_expression,
             ..Default::default()
@@ -45,7 +45,9 @@ fn main() {
     sleep(Duration::from_secs(25));
 
     for _ in 0..capacity {
-        task_builder_vec.pop().unwrap().free();
+        if let Some(mut task_builder) = task_builder_vec.pop() {
+            task_builder.free();
+        }
     }
 
     drop(task_builder_vec);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,14 @@
-use thiserror::Error;
+//! Public error of delay-timer..
 
+use crate::prelude::*;
+
+/// Error enumeration for Cron expression parsing.
 #[derive(Error, Debug)]
-pub enum DataStoreError {
-    #[error("data store disconnected")]
-    Disconnect(#[from] std::io::Error),
-    #[error("the data for key `{0}` is not available")]
-    Redaction(String),
-    #[error("invalid header (expected {expected:?}, found {found:?})")]
-    InvalidHeader {
-        expected: String,
-        found: String,
-    },
-    #[error("unknown data store error")]
-    Unknown,
+pub enum CronExpressionAnalyzeError {
+    /// Access to thread local storage failed.
+    #[error("Thread local storage access failed.")]
+    DisAccess(#[from] std::thread::AccessError),
+    /// Irregular cron expressions that cause parsing failures.
+    #[error("The cron expression was parsed incorrectly.")]
+    DisParse(#[from] cron_error::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 
-/// Error enumeration for Cron expression parsing.
+/// Error enumeration for `Task`-related operations.
 #[derive(Error, Debug)]
 // TODO: Added implementation of Trait for PartialEq, Eq, Clone, etc.
 pub enum TaskError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DataStoreError {
+    #[error("data store disconnected")]
+    Disconnect(#[from] std::io::Error),
+    #[error("the data for key `{0}` is not available")]
+    Redaction(String),
+    #[error("invalid header (expected {expected:?}, found {found:?})")]
+    InvalidHeader {
+        expected: String,
+        found: String,
+    },
+    #[error("unknown data store error")]
+    Unknown,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,3 +12,20 @@ pub enum CronExpressionAnalyzeError {
     #[error("The cron expression was parsed incorrectly.")]
     DisParse(#[from] cron_error::Error),
 }
+
+/// Error enumeration for Handle Instance.
+#[derive(Error, Debug)]
+pub enum HandleInstanceError {
+    /// Missing event sender `timer_event_sender`.
+    #[error("Missing `timer_event_sender`.")]
+    MisEventSender,
+    #[error("Task instance channel exception.")]
+    /// Internal channel communication abnormality.
+    InternalChannelAnomalyT(#[from] channel::TryRecvError),
+    /// Internal channel communication abnormality.
+    #[error("Task instance channel exception.")]
+    InternalChannelAnomaly(#[from] channel::RecvError),
+    /// Running instance of the task is no longer maintained.
+    #[error("Running instance of the task is no longer maintained.")]
+    Expired,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,14 @@ use crate::prelude::*;
 
 /// Error enumeration for Cron expression parsing.
 #[derive(Error, Debug)]
+pub enum TaskError {
+    /// Error variant for Cron expression parsing.
+    #[error("Cron expression analysis error.")]
+    CronExpressionAnalyzeError(#[from] CronExpressionAnalyzeError),
+}
+
+/// Error enumeration for Cron expression parsing.
+#[derive(Error, Debug)]
 pub enum CronExpressionAnalyzeError {
     /// Access to thread local storage failed.
     #[error("Thread local storage access failed.")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 
 /// Error enumeration for Cron expression parsing.
 #[derive(Error, Debug)]
+// TODO: Added implementation of Trait for PartialEq, Eq, Clone, etc.
 pub enum TaskError {
     /// Error variant for Cron expression parsing.
     #[error("Cron expression analysis error.")]
@@ -22,7 +23,7 @@ pub enum CronExpressionAnalyzeError {
 }
 
 /// Error enumeration for Handle Instance.
-#[derive(Error, Debug)]
+#[derive(Error, PartialEq, Eq, Clone, Copy, Debug)]
 pub enum HandleInstanceError {
     /// Missing event sender `timer_event_sender`.
     #[error("Missing `timer_event_sender`.")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,11 +252,10 @@
 #[macro_use]
 pub mod macros;
 pub mod entity;
+pub mod error;
 pub mod prelude;
 pub mod timer;
 pub mod utils;
-pub mod error;
-
 
 pub use anyhow;
 pub use cron_clock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,8 @@ pub mod entity;
 pub mod prelude;
 pub mod timer;
 pub mod utils;
+pub mod error;
+
 
 pub use anyhow;
 pub use cron_clock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,3 +258,4 @@ pub mod utils;
 
 pub use anyhow;
 pub use cron_clock;
+pub use snowflake;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!     Ok(())
 //! }
 //!
-//! fn build_task_async_print() -> Task {
+//! fn build_task_async_print() -> Result<Task, TaskError> {
 //!     let mut task_builder = TaskBuilder::default();
 //!
 //!     let body = create_async_fn_body!({
@@ -70,7 +70,6 @@
 //!         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
 //!         .set_maximun_parallel_runable_num(2)
 //!         .spawn(body)
-//!         .unwrap()
 //! }
 //!
 //! ```
@@ -111,7 +110,7 @@
 //!     delay_timer.stop_delay_timer()
 //! }
 //!
-//! fn build_task_async_print() -> Task {
+//! fn build_task_async_print() -> Result<Task, TaskError> {
 //!     let mut task_builder = TaskBuilder::default();
 //!
 //!     let body = create_async_fn_body!({
@@ -127,7 +126,6 @@
 //!         .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
 //!         .set_maximun_parallel_runable_num(2)
 //!         .spawn(body)
-//!         .unwrap()
 //! }
 //!
 //!
@@ -163,10 +161,9 @@
 //!     .set_frequency_by_candy(CandyFrequency::CountDown(9, CandyCron::Secondly))
 //!     .set_task_id(1)
 //!     .set_maximun_parallel_runable_num(3)
-//!     .spawn(body)
-//!     .unwrap();
+//!     .spawn(body)?;
 //!
-//! delay_timer.add_task(task).unwrap();
+//! delay_timer.add_task(task).ok();
 //!
 //! ```
 //!
@@ -192,7 +189,7 @@
 //!
 //!
 //!
-//! fn build_task(mut task_builder: TaskBuilder) -> Task {
+//! fn build_task(mut task_builder: TaskBuilder) -> Result<Task, TaskError> {
 //!     let body = generate_closure_template(String::from("dynamic"));
 //!
 //!     task_builder
@@ -200,7 +197,6 @@
 //!         .set_task_id(2)
 //!         .set_maximum_running_time(5)
 //!         .spawn(body)
-//!         .unwrap()
 //! }
 //!
 //! pub fn generate_closure_template(
@@ -218,15 +214,15 @@
 //!     }
 //! }
 //!
-//! pub async fn async_template(id: i32, name: String) {
+//! pub async fn async_template(id: i32, name: String) -> AnyResult<()> {
 //!     let client = Client::new();
 //!
 //!     let url = format!("http://httpbin.org/get?id={}&name={}", id, name);
-//!     let uri: Uri = url.parse().unwrap();
-//!     let res = client.get(uri).await.unwrap();
+//!     let uri: Uri = url.parse()?;
+//!     let res = client.get(uri).await?;
 //!     println!("Response: {}", res.status());
 //!     // Concatenate the body stream into a single buffer...
-//!     let buf = hyper::body::to_bytes(res).await.unwrap();
+//!     let buf = hyper::body::to_bytes(res).await?;
 //!     println!("body: {:?}", buf);
 //! }
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,6 +11,7 @@
 //! The prelude may grow over time as additional items see ubiquitous use.
 
 pub use crate::entity::{get_timestamp, get_timestamp_micros, DelayTimer, DelayTimerBuilder};
+pub use crate::error::CronExpressionAnalyzeError;
 pub use crate::macros::*;
 pub use crate::timer::runtime_trace::state::instance;
 pub use crate::timer::runtime_trace::task_handle::DelayTaskHandler;
@@ -26,13 +27,13 @@ pub use crate::utils::convenience::functions::{
     create_default_delay_task_handler, create_delay_task_handler, unblock_process_task_fn,
 };
 
-use thiserror::Error; 
 pub use anyhow::{anyhow, Result as AnyResult};
 pub use cron_clock::{self, error as cron_error, FixedOffset, Local, TimeZone, Utc};
 pub use smol::channel;
 pub use smol::future as future_lite;
 pub use smol::spawn as async_spawn;
 pub use smol::unblock as unblock_spawn;
+pub use thiserror::Error;
 
 /// State of the task run instance.
 pub type InstanceState = usize;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,7 @@
 //! The prelude may grow over time as additional items see ubiquitous use.
 
 pub use crate::entity::{get_timestamp, get_timestamp_micros, DelayTimer, DelayTimerBuilder};
-pub use crate::error::CronExpressionAnalyzeError;
+pub use crate::error::*;
 pub use crate::macros::*;
 pub use crate::timer::runtime_trace::state::instance;
 pub use crate::timer::runtime_trace::task_handle::DelayTaskHandler;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,6 +28,7 @@ pub use crate::utils::convenience::functions::{
 
 pub use anyhow::{anyhow, Result as AnyResult};
 pub use cron_clock::{self, FixedOffset, Local, TimeZone, Utc};
+pub use smol::channel;
 pub use smol::future as future_lite;
 pub use smol::spawn as async_spawn;
 pub use smol::unblock as unblock_spawn;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,8 +26,9 @@ pub use crate::utils::convenience::functions::{
     create_default_delay_task_handler, create_delay_task_handler, unblock_process_task_fn,
 };
 
+use thiserror::Error; 
 pub use anyhow::{anyhow, Result as AnyResult};
-pub use cron_clock::{self, FixedOffset, Local, TimeZone, Utc};
+pub use cron_clock::{self, error as cron_error, FixedOffset, Local, TimeZone, Utc};
 pub use smol::channel;
 pub use smol::future as future_lite;
 pub use smol::spawn as async_spawn;

--- a/src/timer/event_handle.rs
+++ b/src/timer/event_handle.rs
@@ -55,23 +55,23 @@ impl EventHandleBuilder {
         self
     }
 
-    pub(crate) fn build(self) -> EventHandle {
+    pub(crate) fn build(self) -> Option<EventHandle> {
         let task_trace = TaskTrace::default();
-        let sub_wokers = SubWorkers::new(self.timer_event_sender.unwrap());
+        let sub_wokers = SubWorkers::new(self.timer_event_sender?);
 
-        let timer_event_receiver = self.timer_event_receiver.unwrap();
-        let shared_header = self.shared_header.unwrap();
+        let timer_event_receiver = self.timer_event_receiver?;
+        let shared_header = self.shared_header?;
         #[cfg(feature = "status-report")]
         let status_report_sender = self.status_report_sender;
 
-        EventHandle {
+        Some(EventHandle {
             shared_header,
             task_trace,
             timer_event_receiver,
             sub_wokers,
             #[cfg(feature = "status-report")]
             status_report_sender,
-        }
+        })
     }
 }
 
@@ -272,12 +272,9 @@ impl EventHandle {
 
         // copy task_id
         let task_id = task.task_id;
-        self.shared_header
-            .wheel_queue
-            .get_mut(&slot_seed)
-            .unwrap()
-            .value_mut()
-            .add_task(*task);
+        if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_seed) {
+            slot.value_mut().add_task(*task);
+        }
 
         let mut task_mart = TaskMark::default();
         task_mart
@@ -301,12 +298,11 @@ impl EventHandle {
 
         let slot_mark = task_mark.value().get_slot_mark();
 
-        self.shared_header
-            .wheel_queue
-            .get_mut(&slot_mark)
-            .unwrap()
-            .value_mut()
-            .update_task(*task)
+        if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_mark) {
+            return slot.value_mut().update_task(*task);
+        }
+
+        None
     }
 
     // Take the initiative to perform once Task.
@@ -316,22 +312,19 @@ impl EventHandle {
         let slot_mark = task_mark.value().get_slot_mark();
 
         let task = {
-            self.shared_header
-                .wheel_queue
-                .get_mut(&slot_mark)
-                .unwrap()
-                .value_mut()
-                .remove_task(task_id)?
+            if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_mark) {
+                slot.value_mut().remove_task(task_id)?
+            } else {
+                return None;
+            }
         };
 
         let slot_seed = self.shared_header.second_hand.load(Acquire) + 1;
 
-        self.shared_header
-            .wheel_queue
-            .get_mut(&slot_seed)
-            .unwrap()
-            .value_mut()
-            .add_task(task)
+        if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_seed) {
+            return slot.value_mut().add_task(task);
+        }
+        None
     }
 
     // for remove task.
@@ -340,12 +333,11 @@ impl EventHandle {
 
         let slot_mark = task_mark.value().get_slot_mark();
 
-        self.shared_header
-            .wheel_queue
-            .get_mut(&slot_mark)
-            .unwrap()
-            .value_mut()
-            .remove_task(task_id)
+        if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_mark) {
+            return slot.value_mut().remove_task(task_id);
+        }
+
+        None
     }
 
     pub(crate) fn cancel_task(
@@ -354,27 +346,40 @@ impl EventHandle {
         record_id: i64,
         state: usize,
     ) -> Option<Result<()>> {
-        let mut task_mark_ref_mut = self.shared_header.task_flag_map.get_mut(&task_id).unwrap();
-        let task_mark = task_mark_ref_mut.value_mut();
+        if let Some(mut task_mark_ref_mut) = self.shared_header.task_flag_map.get_mut(&task_id) {
+            let task_mark = task_mark_ref_mut.value_mut();
 
-        task_mark.dec_parallel_runable_num();
+            task_mark.dec_parallel_runable_num();
 
-        // Here the user can be notified that the task instance has disappeared via `Instance`.
-        task_mark.notify_cancel_finish(record_id, state);
+            // Here the user can be notified that the task instance has disappeared via `Instance`.
+            task_mark.notify_cancel_finish(record_id, state);
 
-        self.task_trace.quit_one_task_handler(task_id, record_id)
+            return self.task_trace.quit_one_task_handler(task_id, record_id);
+        }
+        Some(Err(anyhow!(
+            "Without the `task_mark_ref_mut` for task_id :{}, record_id : {}, state : {}",
+            task_id,
+            record_id,
+            state
+        )))
     }
 
     pub(crate) fn finish_task(&mut self, task_id: u64, record_id: i64) -> Option<Result<()>> {
-        let mut task_mark_ref_mut = self.shared_header.task_flag_map.get_mut(&task_id).unwrap();
-        let task_mark = task_mark_ref_mut.value_mut();
+        if let Some(mut task_mark_ref_mut) = self.shared_header.task_flag_map.get_mut(&task_id) {
+            let task_mark = task_mark_ref_mut.value_mut();
 
-        task_mark.dec_parallel_runable_num();
+            task_mark.dec_parallel_runable_num();
 
-        // Here the user can be notified that the task instance has disappeared via `Instance`.
-        task_mark.notify_cancel_finish(record_id, state::instance::COMPLETED);
+            // Here the user can be notified that the task instance has disappeared via `Instance`.
+            task_mark.notify_cancel_finish(record_id, state::instance::COMPLETED);
 
-        self.task_trace.quit_one_task_handler(task_id, record_id)
+            return self.task_trace.quit_one_task_handler(task_id, record_id);
+        }
+        Some(Err(anyhow!(
+            "Without the `task_mark_ref_mut` for task_id :{}, record_id : {}",
+            task_id,
+            record_id
+        )))
     }
 
     pub(crate) async fn maintain_task_status(
@@ -383,19 +388,23 @@ impl EventHandle {
         delay_task_handler_box: DelayTaskHandlerBox,
     ) {
         {
-            let mut task_mark = self.shared_header.task_flag_map.get_mut(&task_id).unwrap();
+            if let Some(mut task_mark) = self.shared_header.task_flag_map.get_mut(&task_id) {
+                let task_instances_chain_maintainer_option =
+                    task_mark.value_mut().get_task_instances_chain_maintainer();
 
-            let task_instances_chain_maintainer_option =
-                task_mark.value_mut().get_task_instances_chain_maintainer();
+                if let Some(task_instances_chain_maintainer) =
+                    task_instances_chain_maintainer_option
+                {
+                    let instance = Instance::default()
+                        .set_task_id(task_id)
+                        .set_record_id(delay_task_handler_box.get_record_id());
 
-            if let Some(task_instances_chain_maintainer) = task_instances_chain_maintainer_option {
-                let instance = Instance::default()
-                    .set_task_id(task_id)
-                    .set_record_id(delay_task_handler_box.get_record_id());
-
-                task_instances_chain_maintainer
-                    .push_instance(instance)
-                    .await;
+                    task_instances_chain_maintainer
+                        .push_instance(instance)
+                        .await;
+                }
+            } else {
+                error!("Missing task_mark for task_id : {}", task_id)
             }
         }
 

--- a/src/timer/runtime_trace/sweeper.rs
+++ b/src/timer/runtime_trace/sweeper.rs
@@ -166,6 +166,8 @@ impl RecyclingBins {
 }
 
 mod tests {
+    #[allow(unused_imports)]
+    use anyhow::Result as AnyResult;
 
     #[test]
     fn test_task_valid() -> AnyResult<()> {

--- a/src/timer/runtime_trace/task_handle.rs
+++ b/src/timer/runtime_trace/task_handle.rs
@@ -101,8 +101,7 @@ pub trait DelayTaskHandler: Send + Sync {
 pub struct SafeStructBoxedDelayTaskHandler(pub(crate) Box<dyn DelayTaskHandler>);
 impl Debug for SafeStructBoxedDelayTaskHandler {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        <&Self as Pointer>::fmt(&self, f).unwrap();
-        Ok(())
+        <&Self as Pointer>::fmt(&self, f)
     }
 }
 

--- a/src/timer/runtime_trace/task_instance.rs
+++ b/src/timer/runtime_trace/task_instance.rs
@@ -254,7 +254,7 @@ impl TaskInstancesChain {
 
         self.timer_event_sender
             .clone()
-            .ok_or( HandleInstanceError::MisEventSender)
+            .ok_or(HandleInstanceError::MisEventSender)
     }
 }
 

--- a/src/timer/runtime_trace/task_instance.rs
+++ b/src/timer/runtime_trace/task_instance.rs
@@ -205,7 +205,7 @@ impl TaskInstancesChainMaintainer {
 }
 impl TaskInstancesChain {
     /// Non-blocking get the next task instance.
-    pub fn next(&self) -> AnyResult<TaskInstance> {
+    pub fn next(&self) -> Result<TaskInstance, HandleInstanceError> {
         let timer_event_sender = self.get_timer_event_sender()?;
 
         Ok(self
@@ -218,7 +218,7 @@ impl TaskInstancesChain {
     }
 
     /// Blocking get the next task instance.
-    pub fn next_with_wait(&self) -> AnyResult<TaskInstance> {
+    pub fn next_with_wait(&self) -> Result<TaskInstance, HandleInstanceError> {
         let timer_event_sender = self.get_timer_event_sender()?;
 
         let instance = block_on(self.inner_receiver.recv())?;
@@ -230,7 +230,7 @@ impl TaskInstancesChain {
     }
 
     /// Async-await get the next task instance.
-    pub async fn next_with_async_wait(&self) -> AnyResult<TaskInstance> {
+    pub async fn next_with_async_wait(&self) -> Result<TaskInstance, HandleInstanceError> {
         let timer_event_sender = self.get_timer_event_sender()?;
 
         let instance = self.inner_receiver.recv().await?;
@@ -247,16 +247,14 @@ impl TaskInstancesChain {
         self.inner_state.load(Ordering::Acquire)
     }
 
-    fn get_timer_event_sender(&self) -> AnyResult<Sender<TimerEvent>> {
+    fn get_timer_event_sender(&self) -> Result<Sender<TimerEvent>, HandleInstanceError> {
         if self.get_state() == state::instance_chain::ABANDONED {
-            return Err(anyhow!(
-                "Running instance of the task is no longer maintained."
-            ));
+            return Err(HandleInstanceError::Expired);
         }
 
         self.timer_event_sender
             .clone()
-            .ok_or_else(|| anyhow!("without `timer_event_sender`."))
+            .ok_or( HandleInstanceError::MisEventSender)
     }
 }
 

--- a/src/timer/task.rs
+++ b/src/timer/task.rs
@@ -506,9 +506,7 @@ impl<'a> TaskBuilder<'a> {
     }
 
     /// Spawn a task.
-    // TODO: Create new Error.
-
-    pub fn spawn<F>(self, body: F) -> Result<Task, CronExpressionAnalyzeError>
+    pub fn spawn<F>(self, body: F) -> Result<Task, TaskError>
     where
         F: Fn(TaskContext) -> Box<dyn DelayTaskHandler> + 'static + Send + Sync,
     {

--- a/src/timer/timer_core.rs
+++ b/src/timer/timer_core.rs
@@ -258,7 +258,7 @@ impl Timer {
         timestamp: u64,
         next_second_hand: u64,
     ) -> Option<()> {
-        let record_id: i64 = self.shared_header.snowflakeid_bucket.get_id();
+        let record_id: i64 = self.shared_header.snowflakeid_generator.real_time_generate();
         let task_id: u64 = task.task_id;
 
         if let Some(maximun_parallel_runable_num) = task.maximun_parallel_runable_num {

--- a/src/timer/timer_core.rs
+++ b/src/timer/timer_core.rs
@@ -207,26 +207,24 @@ impl Timer {
             let task_ids;
 
             {
-                let mut slot_mut = self
-                    .shared_header
-                    .wheel_queue
-                    .get_mut(&second_hand)
-                    .unwrap();
-
-                task_ids = slot_mut.value_mut().arrival_time_tasks();
+                if let Some(mut slot_mut) = self.shared_header.wheel_queue.get_mut(&second_hand) {
+                    task_ids = slot_mut.value_mut().arrival_time_tasks();
+                } else {
+                    error!("Missing data for wheel slot {}.", second_hand);
+                    continue;
+                }
             }
 
             for task_id in task_ids {
                 let task_option: Option<Task>;
 
                 {
-                    let mut slot_mut = self
-                        .shared_header
-                        .wheel_queue
-                        .get_mut(&second_hand)
-                        .unwrap();
-
-                    task_option = slot_mut.value_mut().remove_task(task_id);
+                    if let Some(mut slot_mut) = self.shared_header.wheel_queue.get_mut(&second_hand)
+                    {
+                        task_option = slot_mut.value_mut().remove_task(task_id);
+                    } else {
+                        task_option = None;
+                    }
                 }
 
                 if let Some(task) = task_option {

--- a/src/timer/timer_core.rs
+++ b/src/timer/timer_core.rs
@@ -258,7 +258,12 @@ impl Timer {
         timestamp: u64,
         next_second_hand: u64,
     ) -> Option<()> {
-        let record_id: i64 = self.shared_header.snowflakeid_generator.real_time_generate();
+        let record_id: i64 = self
+            .shared_header
+            .id_generator
+            .lock()
+            .await
+            .real_time_generate();
         let task_id: u64 = task.task_id;
 
         if let Some(maximun_parallel_runable_num) = task.maximun_parallel_runable_num {

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -48,6 +48,11 @@ pub mod shell_command {
                     self
                 }
 
+                fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
+                    self.stderr(cfg);
+                    self
+                }
+
                 fn spawn(&mut self) -> AnyResult<$child> {
                     Ok(self.spawn()?)
                 }
@@ -73,6 +78,9 @@ pub mod shell_command {
 
         /// Configuration for the child process's standard output (stdout) handle.
         fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self;
+
+        /// Configuration for the child process's standard error (stderr) handle.
+        fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self;
 
         /// Executes the command as a child process, returning a handle to it.
         fn spawn(&mut self) -> AnyResult<Child>;
@@ -244,9 +252,8 @@ pub mod shell_command {
             }
 
             let mut output = Command::new(command);
-            output.args(args).stdin(stdin);
+            output.args(args).stdin(stdin).stderr(Stdio::piped());
 
-            // TODO: A separate pipe redirection for stderr.
             let process: Child;
             let end_flag = if let Some(stdout_result) = check_redirect_result {
                 let stdout = stdout_result?;
@@ -265,6 +272,7 @@ pub mod shell_command {
                 //     // there should be a default file to record it.
                 //     stdout = Stdio::inherit();
                 // };
+
                 process = output.stdout(stdout).spawn()?;
                 false
             };

--- a/src/utils/parse.rs
+++ b/src/utils/parse.rs
@@ -222,7 +222,7 @@ pub mod shell_command {
             }
 
             let mut parts = command.trim().split_whitespace();
-            let command = parts.next().unwrap();
+            let command = parts.next().ok_or_else(|| anyhow!("Without next part"))?;
             let args = parts;
 
             // Standard input to the current process.
@@ -246,9 +246,10 @@ pub mod shell_command {
             let mut output = Command::new(command);
             output.args(args).stdin(stdin);
 
+            // TODO: A separate pipe redirection for stderr.
             let process: Child;
-            let end_flag = if check_redirect_result.is_some() {
-                let stdout = check_redirect_result.unwrap()?;
+            let end_flag = if let Some(stdout_result) = check_redirect_result {
+                let stdout = stdout_result?;
                 process = output.stdout(stdout).spawn()?;
                 true
             } else {

--- a/src/utils/status_report.rs
+++ b/src/utils/status_report.rs
@@ -17,18 +17,18 @@ pub struct StatusReporter {
 impl StatusReporter {
 
     /// Non-blocking get `PublicEvent` via `StatusReporter`.
-    pub fn next_public_event(&self) -> AnyResult<PublicEvent> {
+    pub fn next_public_event(&self) -> Result<PublicEvent, channel::TryRecvError> {
         let event = self.inner.try_recv()?;
         Ok(event)
     }
 
     /// Blocking get `PublicEvent` via `StatusReporter`.
-    pub fn next_public_event_with_wait(&self) -> AnyResult<PublicEvent> {
-        Ok(block_on(self.inner.recv())?)
+    pub fn next_public_event_with_wait(&self) -> Result<PublicEvent, channel::RecvError> {
+        block_on(self.inner.recv())
     }
 
     /// Async get `PublicEvent` via `StatusReporter`.
-    pub async fn next_public_event_with_async_wait(&self) -> AnyResult<PublicEvent> {
+    pub async fn next_public_event_with_async_wait(&self) -> Result<PublicEvent, channel::RecvError> {
         Ok(self.inner.recv().await?)
     }
 

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -196,7 +196,11 @@ fn go_works() -> AnyResult<()> {
         i = i + 1;
 
         // Coordinates the inner-Runtime with the external(test-thread) clock.(200_000 is a buffer.)
-        next_exec_time = dbg!(schedule_itertor.next()?.timestamp_millis()) as u128 * 1000;
+        next_exec_time = dbg!(schedule_itertor
+            .next()
+            .ok_or(anyhow!("Without next element."))?
+            .timestamp_millis()) as u128
+            * 1000;
         current_time = get_timestamp_micros();
         park_time = next_exec_time
             .checked_sub(current_time)


### PR DESCRIPTION
# Version 0.5.0 

v0.5.0 New features:


    1. Remove all unwrap() calls.
    
    2. Redefined the errors exposed to the outside (encapsulated by `thiserror`) as libs to never expose `anyhow::Error` to the outside.
    
      2.1. Set separate `TaskError`. for `Task`-related operations.
      2.2. Set separate `HandleInstanceError`. for `Task-Instance`-related operations.
    
    
    3. Optimized shell command parsing function, set exclusive pipeline for derived subprocesses -stderr.


Update dependency :
    Add, `thiserror`.


Enriched documentation.