### PR TITLE
Version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Version 0.7.0
+
+v0.7.0 New features:
+
+    1. Fix the bugs before V0.6.1, When receive a timeout event from the `sweeper`, it is possible that the task has been completed.
+    So can't just call cancel.
+
+      Two options fix it.
+        1. `sweeper` Remove the recycling unit when the task is finished or cancelled.(Because rust's `BinaryHeap` does not support removing specific elements, this scheme is not used.)
+
+        2. The public event is sent only after the internal event has been processed and succeeded. (Adopted.)
+  
+    2. Adjust api names (runnable -> runnable, maximun -> maximum).
+
 # Version 0.6.1
 
 v0.6.1 New features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delay_timer"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["binchengZhao <binchengZhao@outlook.com>"]
 edition = "2018"
 repository = "https://github.com/BinChengZhao/delay-timer"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fn build_task_async_print() -> Result<Task, TaskError> {
     task_builder
         .set_task_id(1)
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
-        .set_maximun_parallel_runable_num(2)
+        .set_maximum_parallel_runnable_num(2)
         .spawn(body)
 }
 
@@ -125,7 +125,7 @@ fn build_task_async_print() -> Result<Task, TaskError> {
     task_builder
         .set_task_id(1)
         .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
-        .set_maximun_parallel_runable_num(2)
+        .set_maximum_parallel_runnable_num(2)
         .spawn(body)
 }
 
@@ -158,7 +158,7 @@ fn build_task_async_print() -> Result<Task, TaskError> {
  let task = TaskBuilder::default()
      .set_frequency_by_candy(CandyFrequency::CountDown(9, CandyCron::Secondly))
      .set_task_id(1)
-     .set_maximun_parallel_runable_num(3)
+     .set_maximum_parallel_runnable_num(3)
      .spawn(body)?;
 
  delay_timer.add_task(task);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -56,7 +56,7 @@ fn build_task_async_print() -> Result<Task, TaskError> {
     task_builder
         .set_task_id(1)
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
-        .set_maximun_parallel_runable_num(2)
+        .set_maximum_parallel_runnable_num(2)
         .spawn(body)
 }
 

--- a/examples/demo_async_std.rs
+++ b/examples/demo_async_std.rs
@@ -52,7 +52,7 @@ fn build_task_async_print() -> Result<Task, TaskError> {
     task_builder
         .set_task_id(1)
         .set_frequency(Frequency::Repeated(s_r))
-        .set_maximun_parallel_runable_num(2)
+        .set_maximum_parallel_runnable_num(2)
         .spawn(body)
 }
 
@@ -64,6 +64,6 @@ fn build_task_async_execute_process() -> Result<Task, TaskError> {
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
         .set_task_id(3)
         .set_maximum_running_time(10)
-        .set_maximun_parallel_runable_num(1)
+        .set_maximum_parallel_runnable_num(1)
         .spawn(body)
 }

--- a/examples/demo_async_tokio.rs
+++ b/examples/demo_async_tokio.rs
@@ -55,7 +55,7 @@ fn build_task_async_print() -> Result<Task, TaskError> {
     task_builder
         .set_task_id(1)
         .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
-        .set_maximun_parallel_runable_num(2)
+        .set_maximum_parallel_runnable_num(2)
         .spawn(body)
 }
 
@@ -67,6 +67,6 @@ fn build_task_async_execute_process() -> Result<Task, TaskError> {
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
         .set_task_id(3)
         .set_maximum_running_time(10)
-        .set_maximun_parallel_runable_num(1)
+        .set_maximum_parallel_runnable_num(1)
         .spawn(body)
 }

--- a/examples/dynamic_cancel.rs
+++ b/examples/dynamic_cancel.rs
@@ -86,7 +86,7 @@ fn build_task_async_print() -> Result<Task, TaskError> {
     task_builder
         .set_task_id(1)
         .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
-        .set_maximun_parallel_runable_num(2)
+        .set_maximum_parallel_runnable_num(2)
         .spawn(body)
 }
 
@@ -98,6 +98,6 @@ fn build_task_async_execute_process() -> Result<Task, TaskError> {
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
         .set_task_id(3)
         .set_maximum_running_time(10)
-        .set_maximun_parallel_runable_num(1)
+        .set_maximum_parallel_runnable_num(1)
         .spawn(body)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //!     task_builder
 //!         .set_task_id(1)
 //!         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
-//!         .set_maximun_parallel_runable_num(2)
+//!         .set_maximum_parallel_runnable_num(2)
 //!         .spawn(body)
 //! }
 //!
@@ -124,7 +124,7 @@
 //!     task_builder
 //!         .set_task_id(1)
 //!         .set_frequency(Frequency::Repeated("*/6 * * * * * *"))
-//!         .set_maximun_parallel_runable_num(2)
+//!         .set_maximum_parallel_runnable_num(2)
 //!         .spawn(body)
 //! }
 //!
@@ -160,7 +160,7 @@
 //! let task = TaskBuilder::default()
 //!     .set_frequency_by_candy(CandyFrequency::CountDown(9, CandyCron::Secondly))
 //!     .set_task_id(1)
-//!     .set_maximun_parallel_runable_num(3)
+//!     .set_maximum_parallel_runnable_num(3)
 //!     .spawn(body).expect("");
 //!
 //! delay_timer.add_task(task).ok();

--- a/src/timer/event_handle.rs
+++ b/src/timer/event_handle.rs
@@ -170,79 +170,78 @@ impl EventHandle {
         #[cfg(feature = "status-report")]
         if let Some(status_report_sender) = self.status_report_sender.take() {
             while let Ok(event) = self.timer_event_receiver.recv().await {
-                if let Ok(public_event) = PublicEvent::try_from(&event) {
+                let public_event_result = PublicEvent::try_from(&event);
+
+                let dispatch_result = self.event_dispatch(event).await;
+
+                if let Ok(public_event) = dispatch_result
+                    .map_err(|e| {
+                        error!("{}", &e);
+                        e
+                    })
+                    .and(public_event_result)
+                {
                     status_report_sender
                         .send(public_event)
                         .await
                         .unwrap_or_else(|e| print!("{}", e));
                 }
-                self.event_dispatch(event).await;
             }
             return;
         }
 
         // Did not turn on `feature` or no `status_report_sender` go this piece of logic.
         while let Ok(event) = self.timer_event_receiver.recv().await {
-            self.event_dispatch(event).await;
+            self.event_dispatch(event)
+                .await
+                .map_err(|e| error!("{}", e))
+                .ok();
         }
     }
 
-    pub(crate) async fn event_dispatch(&mut self, event: TimerEvent) {
+    pub(crate) async fn event_dispatch(&mut self, event: TimerEvent) -> Result<()> {
         match event {
             TimerEvent::StopTimer => {
                 self.shared_header.shared_motivation.store(false, Release);
-                return;
-            }
-            TimerEvent::AddTask(task) => {
-                self.add_task(task)
-                    .map(|task_mark| self.record_task_mark(task_mark))
-                    .map_err(|e| error!("{}", e))
-                    .ok();
+                Ok(())
             }
 
+            TimerEvent::AddTask(task) => self
+                .add_task(task)
+                .map(|task_mark| self.record_task_mark(task_mark)),
+
             TimerEvent::InsertTask(task, task_instances_chain_maintainer) => {
-                self.add_task(task)
-                    .map(|mut task_mark| {
-                        task_mark
-                            .set_task_instances_chain_maintainer(task_instances_chain_maintainer);
-                        self.record_task_mark(task_mark);
-                    })
-                    .map_err(|e| error!("{}", e))
-                    .ok();
+                self.add_task(task).map(|mut task_mark| {
+                    task_mark.set_task_instances_chain_maintainer(task_instances_chain_maintainer);
+                    self.record_task_mark(task_mark);
+                })
             }
 
             TimerEvent::UpdateTask(task) => {
                 self.update_task(task).await;
+                Ok(())
             }
 
-            TimerEvent::AdvanceTask(task_id) => {
-                self.advance_task(task_id).await;
-            }
+            TimerEvent::AdvanceTask(task_id) => self.advance_task(task_id).await,
 
             TimerEvent::RemoveTask(task_id) => {
-                self.remove_task(task_id).await;
+                let remove_result = self.remove_task(task_id).await;
 
                 self.shared_header.task_flag_map.remove(&task_id);
+                remove_result
             }
             TimerEvent::CancelTask(task_id, record_id) => {
-                self.cancel_task(task_id, record_id, state::instance::CANCELLED);
+                self.cancel_task(task_id, record_id, state::instance::CANCELLED)
             }
 
-            // TODO: When receive a timeout event from the `sweeper`, it is possible that the task has been completed.
-            // So can't just call cancel.
-
-            // Two options fix it.
-            // 1. `sweeper` Remove the recycling unit when the task is finished or cancelled.
-            // 2. A public event is sent to the outside after the internal processing of the completed event at the time of event assignment.
-
-
             TimerEvent::TimeoutTask(task_id, record_id) => {
-                self.cancel_task(task_id, record_id, state::instance::TIMEOUT);
+                self.cancel_task(task_id, record_id, state::instance::TIMEOUT)
             }
 
             TimerEvent::AppendTaskHandle(task_id, delay_task_handler_box) => {
                 self.maintain_task_status(task_id, delay_task_handler_box)
                     .await;
+                Ok(())
             }
 
             TimerEvent::FinishTask(FinishTaskBody {
@@ -251,7 +250,7 @@ impl EventHandle {
                 //TODO: maintain a outside-task-handle , through it pass the _finish_time and final-state.
                 // Provide a separate start time for the external, record_id time with a delay.
                 // Or use snowflake.real_time to generate record_id , so you don't have to add a separate field.
-                self.finish_task(task_id, record_id);
+                self.finish_task(task_id, record_id)
             }
         }
     }
@@ -292,7 +291,7 @@ impl EventHandle {
         task_mart
             .set_task_id(task_id)
             .set_slot_mark(slot_seed)
-            .set_parallel_runable_num(0);
+            .set_parallel_runnable_num(0);
 
         Ok(task_mart)
     }
@@ -318,16 +317,30 @@ impl EventHandle {
     }
 
     // Take the initiative to perform once Task.
-    pub(crate) async fn advance_task(&mut self, task_id: u64) -> Option<Task> {
-        let task_mark = self.shared_header.task_flag_map.get(&task_id)?;
+    pub(crate) async fn advance_task(&mut self, task_id: u64) -> Result<()> {
+        let task_mark = self
+            .shared_header
+            .task_flag_map
+            .get(&task_id)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Fn : `advance_task`, No task-mark found (task-id: {} )",
+                    task_id
+                )
+            })?;
 
         let slot_mark = task_mark.value().get_slot_mark();
 
         let mut task = {
             if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_mark) {
-                slot.value_mut().remove_task(task_id)?
+                slot.value_mut()
+                    .remove_task(task_id)
+                    .ok_or_else(|| anyhow!("Fn : `advance_task`, No task found (task-id: {} )", task_id))?
             } else {
-                return None;
+                return Err(anyhow!(
+                    "Fn : `advance_task`, No task found (task-id: {} )",
+                    task_id
+                ));
             }
         };
         task.clear_cylinder_line();
@@ -335,64 +348,82 @@ impl EventHandle {
         let slot_seed = self.shared_header.second_hand.load(Acquire) + 1;
 
         if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_seed) {
-            return slot.value_mut().add_task(task);
+            slot.value_mut().add_task(task);
+            return Ok(());
         }
-        None
+
+        Err(anyhow!(
+            "Fn : `advance_task`, No slot found (slot: {} )",
+            slot_seed
+        ))
     }
 
     // for remove task.
-    pub(crate) async fn remove_task(&mut self, task_id: u64) -> Option<Task> {
-        let task_mark = self.shared_header.task_flag_map.get(&task_id)?;
+    pub(crate) async fn remove_task(&mut self, task_id: u64) -> Result<()> {
+        let task_mark = self
+            .shared_header
+            .task_flag_map
+            .get(&task_id)
+            .ok_or_else(|| {
+                anyhow!(
+                    " Fn : `remove_task`,  No task-mark found (task-id: {} )",
+                    task_id
+                )
+            })?;
 
         let slot_mark = task_mark.value().get_slot_mark();
 
         if let Some(mut slot) = self.shared_header.wheel_queue.get_mut(&slot_mark) {
-            return slot.value_mut().remove_task(task_id);
+            slot.value_mut().remove_task(task_id);
+            return Ok(());
         }
 
-        None
+        Err(anyhow!(
+            "Fn : `remove_task`, No slot found (slot: {} )",
+            slot_mark
+        ))
     }
 
-    pub(crate) fn cancel_task(
-        &mut self,
-        task_id: u64,
-        record_id: i64,
-        state: usize,
-    ) -> Option<Result<()>> {
+    pub(crate) fn cancel_task(&mut self, task_id: u64, record_id: i64, state: usize) -> Result<()> {
         if let Some(mut task_mark_ref_mut) = self.shared_header.task_flag_map.get_mut(&task_id) {
             let task_mark = task_mark_ref_mut.value_mut();
 
-            task_mark.dec_parallel_runable_num();
+            // The cancellation operation is executed first, and then the outside world is notified of the cancellation event.
+            // If the operation object does not exist in the middle, it should return early.
+            self.task_trace.quit_one_task_handler(task_id, record_id)?;
 
             // Here the user can be notified that the task instance has disappeared via `Instance`.
-            task_mark.notify_cancel_finish(record_id, state);
+            task_mark.notify_cancel_finish(record_id, state)?;
 
-            return self.task_trace.quit_one_task_handler(task_id, record_id);
+            task_mark.dec_parallel_runnable_num();
+
+            return Ok(());
         }
-        Some(Err(anyhow!(
-            "Without the `task_mark_ref_mut` for task_id :{}, record_id : {}, state : {}",
+        Err(anyhow!(
+            "Fn : `cancel_task`, Without the `task_mark_ref_mut` for task_id :{}, record_id : {}, state : {}",
             task_id,
             record_id,
             state
-        )))
+        ))
     }
 
-    pub(crate) fn finish_task(&mut self, task_id: u64, record_id: i64) -> Option<Result<()>> {
+    pub(crate) fn finish_task(&mut self, task_id: u64, record_id: i64) -> Result<()> {
         if let Some(mut task_mark_ref_mut) = self.shared_header.task_flag_map.get_mut(&task_id) {
             let task_mark = task_mark_ref_mut.value_mut();
-
-            task_mark.dec_parallel_runable_num();
+            self.task_trace.quit_one_task_handler(task_id, record_id)?;
 
             // Here the user can be notified that the task instance has disappeared via `Instance`.
-            task_mark.notify_cancel_finish(record_id, state::instance::COMPLETED);
+            task_mark.notify_cancel_finish(record_id, state::instance::COMPLETED)?;
 
-            return self.task_trace.quit_one_task_handler(task_id, record_id);
+            task_mark.dec_parallel_runnable_num();
+
+            return Ok(());
         }
-        Some(Err(anyhow!(
-            "Without the `task_mark_ref_mut` for task_id :{}, record_id : {}",
+        Err(anyhow!(
+            "Fn : `finish_task`, Without the `task_mark_ref_mut` for task_id :{}, record_id : {}",
             task_id,
             record_id
-        )))
+        ))
     }
 
     pub(crate) async fn maintain_task_status(

--- a/src/timer/event_handle.rs
+++ b/src/timer/event_handle.rs
@@ -228,6 +228,14 @@ impl EventHandle {
                 self.cancel_task(task_id, record_id, state::instance::CANCELLED);
             }
 
+            // TODO: When receive a timeout event from the `sweeper`, it is possible that the task has been completed.
+            // So can't just call cancel.
+
+            // Two options fix it.
+            // 1. `sweeper` Remove the recycling unit when the task is finished or cancelled.
+            // 2. A public event is sent to the outside after the internal processing of the completed event at the time of event assignment.
+
+
             TimerEvent::TimeoutTask(task_id, record_id) => {
                 self.cancel_task(task_id, record_id, state::instance::TIMEOUT);
             }

--- a/src/timer/timer_core.rs
+++ b/src/timer/timer_core.rs
@@ -267,8 +267,8 @@ impl Timer {
             .real_time_generate();
         let task_id: u64 = task.task_id;
 
-        if let Some(maximun_parallel_runable_num) = task.maximun_parallel_runable_num {
-            let parallel_runable_num: u64;
+        if let Some(maximum_parallel_runnable_num) = task.maximum_parallel_runnable_num {
+            let parallel_runnable_num: u64;
 
             {
                 let task_flag_map =
@@ -278,12 +278,12 @@ impl Timer {
                         .ok_or_else(|| {
                             anyhow!("Can't get task_flag_map for task : {}", task.task_id)
                         })?;
-                parallel_runable_num = task_flag_map.value().get_parallel_runable_num();
+                parallel_runnable_num = task_flag_map.value().get_parallel_runnable_num();
             }
 
-            //if runable_task.parallel_runable_num >= task.maximun_parallel_runable_num doesn't run it.
+            //if runnable_task.parallel_runnable_num >= task.maximum_parallel_runnable_num doesn't run it.
 
-            if parallel_runable_num >= maximun_parallel_runable_num {
+            if parallel_runnable_num >= maximum_parallel_runnable_num {
                 return self.handle_task(task, timestamp, next_second_hand, false);
             }
         }
@@ -322,7 +322,7 @@ impl Timer {
         mut task: Task,
         timestamp: u64,
         next_second_hand: u64,
-        update_runable_num: bool,
+        update_runnable_num: bool,
     ) -> AnyResult<()> {
         let task_id: u64 = task.task_id;
 
@@ -355,8 +355,8 @@ impl Timer {
                 .ok_or_else(|| anyhow!("can't get task_flag_map for task :{}", task_id))?;
 
             task_flag_map.value_mut().set_slot_mark(slot_seed);
-            if update_runable_num {
-                task_flag_map.value_mut().inc_parallel_runable_num();
+            if update_runnable_num {
+                task_flag_map.value_mut().inc_parallel_runnable_num();
             }
         }
         Ok(())

--- a/src/utils/status_report.rs
+++ b/src/utils/status_report.rs
@@ -120,7 +120,7 @@ pub enum PublicEvent {
 }
 
 impl TryFrom<&TimerEvent> for PublicEvent {
-    type Error = &'static str;
+    type Error = anyhow::Error;
 
     fn try_from(timer_event: &TimerEvent) -> Result<Self, Self::Error> {
         match timer_event {
@@ -137,7 +137,7 @@ impl TryFrom<&TimerEvent> for PublicEvent {
                 Ok(PublicEvent::TimeoutTask(*task_id, *record_id))
             }
 
-            _ => Err("PublicEvent only accepts timer_event some variant( RemoveTask, CancelTask ,FinishTask )!"),
+            _ => Err(anyhow!("PublicEvent only accepts timer_event some variant( RemoveTask, CancelTask ,FinishTask )!")),
         }
     }
 }

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -45,8 +45,8 @@ fn test_instance_state() -> anyhow::Result<()> {
     // Just got the instance when it was still running.
     assert_eq!(instance.get_state(), instance::RUNNING);
 
-    // The task execution is completed after about 110 millisecond.
-    park_timeout(Duration::from_millis(110));
+    // The task execution is completed.
+    park_timeout(Duration::from_millis(200));
 
     // This should be the completed state.
     assert_eq!(instance.get_state(), instance::COMPLETED);

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -25,7 +25,7 @@ fn test_instance_state() -> anyhow::Result<()> {
     let task = TaskBuilder::default()
         .set_frequency_by_candy(CandyFrequency::CountDown(4, CandyCron::Secondly))
         .set_task_id(1)
-        .set_maximun_parallel_runable_num(3)
+        .set_maximum_parallel_runnable_num(3)
         .spawn(body)?;
     let task_instance_chain = delay_timer.insert_task(task)?;
 
@@ -66,7 +66,7 @@ fn test_instance_timeout_state() -> anyhow::Result<()> {
         .set_frequency_by_candy(CandyFrequency::CountDown(4, CandyCron::Secondly))
         .set_task_id(1)
         .set_maximum_running_time(2)
-        .set_maximun_parallel_runable_num(3)
+        .set_maximum_parallel_runnable_num(3)
         .spawn(body)?;
     let task_instance_chain = delay_timer.insert_task(task)?;
 
@@ -98,7 +98,7 @@ fn test_shell_task_instance_timeout_state() -> anyhow::Result<()> {
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
         .set_task_id(3)
         .set_maximum_running_time(3)
-        .set_maximun_parallel_runable_num(1)
+        .set_maximum_parallel_runnable_num(1)
         .spawn(body)?;
 
     let task_instance_chain = delay_timer.insert_task(task)?;
@@ -137,7 +137,7 @@ fn test_shell_task_instance_complete_state() -> anyhow::Result<()> {
         .set_frequency_by_candy(CandyFrequency::Repeated(CandyCron::Secondly))
         .set_task_id(3)
         .set_maximum_running_time(3)
-        .set_maximun_parallel_runable_num(1)
+        .set_maximum_parallel_runnable_num(1)
         .spawn(body)?;
 
     let task_instance_chain = delay_timer.insert_task(task)?;
@@ -224,7 +224,7 @@ fn test_advance() -> AnyResult<()> {
 }
 
 #[test]
-fn test_maximun_parallel_runable_num() -> AnyResult<()> {
+fn test_maximum_parallel_runnable_num() -> AnyResult<()> {
     let delay_timer = DelayTimer::new();
     let share_num = Arc::new(AtomicU64::new(0));
     let share_num_bunshin = share_num.clone();
@@ -239,7 +239,7 @@ fn test_maximun_parallel_runable_num() -> AnyResult<()> {
     let task = TaskBuilder::default()
         .set_frequency_by_candy(CandyFrequency::CountDown(4, CandyCron::Secondly))
         .set_task_id(1)
-        .set_maximun_parallel_runable_num(3)
+        .set_maximum_parallel_runnable_num(3)
         .spawn(body)?;
     delay_timer.add_task(task)?;
 


### PR DESCRIPTION
v0.7.0 New features:

    1. Fix the bugs before V0.6.1, When receive a timeout event from the `sweeper`, it is possible that the task has been completed.
    So can't just call cancel.

      Two options fix it.
        1. `sweeper` Remove the recycling unit when the task is finished or cancelled.(Because rust's `BinaryHeap` does not support removing specific elements, this scheme is not used.)

        2. The public event is sent only after the internal event has been processed and succeeded. (Adopted.)
  
    2. Adjust api names (runnable -> runnable, maximun -> maximum).