### PR TITLE
Version 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /target/
 /examples/target/
 /examples/*.lock
-
+.DS_Store
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Version 0.8.0
+
+v0.8.0 New features:
+
+    1. Optimized the api for custom tokio runtime, better api definition, better experience.
+
+      Api changes.
+        1.  Added: `tokio_runtime_by_default` & `tokio_runtime_by_custom` & `tokio_runtime_shared_by_custom` .
+
+        2. Private: `tokio_runtime`.
+  
+    2. Optimized the method of canceling task instances, no error log is recorded when canceling a task failure after timeout.
+
+    3. Fix the compile error about `quit_one_task_handler` under nightly version.
 # Version 0.7.0
 
 v0.7.0 New features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delay_timer"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["binchengZhao <binchengZhao@outlook.com>"]
 edition = "2018"
 repository = "https://github.com/BinChengZhao/delay-timer"

--- a/examples/cycle_tokio_task.rs
+++ b/examples/cycle_tokio_task.rs
@@ -8,7 +8,9 @@ use std::thread::{current, park, Thread};
 
 fn main() -> Result<()> {
     // Build an DelayTimer that uses the default configuration of the Tokio runtime internally.
-    let delay_timer = DelayTimerBuilder::default().tokio_runtime(None).build();
+    let delay_timer = DelayTimerBuilder::default()
+        .tokio_runtime_by_default()
+        .build();
 
     // Develop a task that runs in an asynchronous cycle (using a custom asynchronous template).
     delay_timer.add_task(build_task_customized_async_task()?)?;

--- a/examples/dynamic_cancel.rs
+++ b/examples/dynamic_cancel.rs
@@ -37,7 +37,7 @@ fn async_cancel() -> Result<()> {
 
     // Build an DelayTimer that uses the Customize a tokio runtime.
     let delay_timer = DelayTimerBuilder::default()
-        .tokio_runtime(Some(tokio_rt.clone()))
+        .tokio_runtime_shared_by_custom(tokio_rt.clone())
         .build();
 
     tokio_rt.block_on(async {

--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -1,0 +1,69 @@
+use anyhow::Result;
+use delay_timer::prelude::*;
+use smol::Timer;
+use std::any::{type_name, Any};
+use std::thread::park_timeout;
+use std::time::Duration;
+use surf;
+
+// cargo run --package delay_timer --example generic --features=full
+
+fn main() -> Result<()> {
+    let delay_timer = DelayTimerBuilder::default().enable_status_report().build();
+
+    // Develop tasks with generic parameters. that runs in an asynchronous cycle.
+    delay_timer.add_task(build_generic_task_async_request(Dog)?)?;
+
+    // Give a little time to observe the output.
+    park_timeout(Duration::from_secs(30));
+
+    // No new tasks are accepted; running tasks are not affected.
+    delay_timer.stop_delay_timer()?;
+
+    Ok(())
+}
+
+fn build_generic_task_async_request<T: Animal>(animal: T) -> Result<Task, TaskError> {
+    let mut task_builder = TaskBuilder::default();
+
+    let other_animal = Cat;
+    let int_animal = 1;
+
+    let body = create_async_fn_body!((animal, other_animal, int_animal){
+        if let Ok(mut res) = surf::get("https://httpbin.org/get").await {
+            dbg!(res.body_string().await.unwrap_or_default());
+            animal_ref.call();
+            other_animal_ref.call();
+            <i32 as Animal>::call(&int_animal_ref);
+
+
+            Timer::after(Duration::from_secs(3)).await;
+            dbg!("Task2 is done.");
+        }
+    });
+
+    task_builder
+        .set_frequency(Frequency::CountDown(15, "* * * * * * *"))
+        .set_task_id(2)
+        .set_maximum_running_time(5)
+        .spawn(body)
+}
+
+trait ThreadSafe: Any + Sized + Clone + Send + Sync + 'static {}
+impl<T: Any + Sized + Clone + Send + Sync + 'static> ThreadSafe for T {}
+
+trait Animal: ThreadSafe {
+    fn call(&self);
+}
+
+impl<T: ThreadSafe> Animal for T {
+    fn call(&self) {
+        println!("this is {}", type_name::<T>());
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Dog;
+
+#[derive(Clone, Copy)]
+struct Cat;

--- a/src/timer/runtime_trace/sweeper.rs
+++ b/src/timer/runtime_trace/sweeper.rs
@@ -145,6 +145,7 @@ impl RecyclingBins {
                 match self.recycle_unit_sources.recv().await {
                     Ok(recycle_unit) => {
                         let mut recycle_unit_heap = self.recycle_unit_heap.lock().await;
+
                         (&mut recycle_unit_heap).push(Reverse(recycle_unit));
                     }
 

--- a/tests/simulation.rs
+++ b/tests/simulation.rs
@@ -1,19 +1,16 @@
 use delay_timer::prelude::*;
 
 use std::str::FromStr;
-use std::sync::atomic::{
-    AtomicUsize,
-    Ordering::{Acquire, Release},
-};
-use std::sync::{
-    atomic::{AtomicI32, AtomicU64},
-    Arc,
-};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::{Acquire, Release};
+use std::sync::atomic::{AtomicI32, AtomicU64};
+use std::sync::Arc;
 use std::thread::{self, park_timeout};
 use std::time::Duration;
 
 use smol::Timer;
 
+// TODO: Please turn on `--features=full` before test.
 #[test]
 fn test_instance_state() -> anyhow::Result<()> {
     let delay_timer = DelayTimer::new();
@@ -59,7 +56,9 @@ fn test_instance_timeout_state() -> anyhow::Result<()> {
     let delay_timer = DelayTimer::new();
 
     let body = create_async_fn_body!({
+        println!("test_instance_timeout_state");
         Timer::after(Duration::from_secs(3)).await;
+        println!("test_instance_timeout_state end.");
     });
 
     let task = TaskBuilder::default()
@@ -76,8 +75,8 @@ fn test_instance_timeout_state() -> anyhow::Result<()> {
     // The task was still running when the instance was first obtained.
     assert_eq!(instance.get_state(), instance::RUNNING);
 
-    // The task execution is timeout after about 2.1 second.
-    park_timeout(Duration::from_secs_f64(2.1));
+    // The task execution is timeout after about 3 second.
+    park_timeout(Duration::from_secs(3));
 
     // This should be the completed state.
     assert_eq!(instance.get_state(), instance::TIMEOUT);


### PR DESCRIPTION
v0.8.0 New features:

    1. Optimized the api for custom tokio runtime, better api definition, better experience.

      Api changes.
        1.  Added: `tokio_runtime_by_default` & `tokio_runtime_by_custom` & `tokio_runtime_shared_by_custom` .

        2. Private: `tokio_runtime`.
  
    2. Optimized the method of canceling task instances, no error log is recorded when canceling a task failure after timeout.

    3. Fix the compile error about `quit_one_task_handler` under nightly version.