### PR TITLE
autocfg should point at correct build script

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -28,6 +28,6 @@ fn main() -> Result<()> {
 
     // (optional) We don't need to rerun for anything external.
     // In order to see the compilation parameters at `cargo check --verbose` time, keep it.
-    autocfg::rerun_path("build.rs");
+    autocfg::rerun_path("build/build.rs");
     Ok(())
 }


### PR DESCRIPTION
If "cargo:rerun-if-changed" is pointed at a non-existent path, then cargo will recompile delay-timer (and everything that depends on it) every time `cargo build` is run, instead of only recompiling things that have changed.